### PR TITLE
fix: add `.v0` prefix to `github-release` binary

### DIFF
--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -13,7 +13,8 @@ throw() {
 [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
 
 # Ensure https://github.com/aktau/github-release is installed.
-command -v github-release > /dev/null 2>&1 || throw "Unable to locate github-release binary"
+# NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
+command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Parse the version number.
 PKG_VERSION=
@@ -33,7 +34,7 @@ done < pom.xml
 echo "Releasing v$PKG_VERSION"
 
 # Create a release.
-github-release release \
+github-release.v0 release \
   --user "$CIRCLE_PROJECT_USERNAME" \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -13,7 +13,8 @@ throw() {
 [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
 
 # Ensure https://github.com/aktau/github-release is installed.
-command -v github-release > /dev/null 2>&1 || throw "Unable to locate github-release binary"
+# NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
+command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Read version number. Attempt `lerna.json` before `package.json`.
 PKG_VERSION=
@@ -32,7 +33,7 @@ fi
 echo "Releasing v$PKG_VERSION"
 
 # Create a release.
-github-release release \
+github-release.v0 release \
   --user "$CIRCLE_PROJECT_USERNAME" \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \

--- a/src/ruby-github-release.sh
+++ b/src/ruby-github-release.sh
@@ -13,7 +13,8 @@ throw() {
 [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
 
 # Ensure https://github.com/aktau/github-release is installed.
-command -v github-release > /dev/null 2>&1 || throw "Unable to locate github-release binary"
+# NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
+command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Ensure a single .gemspec file is present.
 GEMSPEC_COUNT=$(find . -type f -name "*.gemspec" | wc -l | tr -d "[:space:]")
@@ -31,7 +32,7 @@ PKG_VERSION=$(perl -nle 'print "$1" if m{spec\.version\s+=\s"(.*)"}' "$GEMSPEC_F
 echo "Releasing v$PKG_VERSION"
 
 # Create a release.
-github-release release \
+github-release.v0 release \
   --user "$CIRCLE_PROJECT_USERNAME" \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \


### PR DESCRIPTION
This patch updates the `github-release` binary name. Originally, we were going to pull the software directly from GitHub (via `go get https://github.com/aktau/github-release`), but to avoid dealing with breaking changes, we're always installing v0 (via `go get gopkg.in/aktau/github-release.v0`) instead. As a side-effect of pulling the v0 binary down, we must reference it with a `.v0` suffix.