### PR TITLE
fix: add name and version arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ The `zip-dir-upload-to-artifactory` script zip's a given directory and uploads t
 | Argument | Description |
 |---|---|
 | dir ($1) | **(Mandatory)** the directory to zip |
-| prefix ($2) | **(Optional)** a prefix tot he zip file name |
+| prefix ($2) | **(Optional)** a prefix to the zip file name |
+| name ($2) | **(Optional)** name used as path under artifactory repository to where the zip file will be uploaded |
+| version ($2) | **(Optional)** version number used to construct the zip file name |
 
 **Usage:**
 

--- a/src/zip-dir-upload-to-artifactory.sh
+++ b/src/zip-dir-upload-to-artifactory.sh
@@ -34,13 +34,23 @@ if ! [ -x "$(command -v jq)" ]; then
   throw "Error: jq is not installed."
 fi
 
-# Get name & version of the library from `package.json`
-name=$(< package.json jq -r .name)
-version=$(< package.json jq -r .version)
-
 # save args to variables
 directory=$1
 prefix=$2
+name=$3
+version=$4
+
+# get `name` from `package.json` of the library, if not supplied as an argument 
+if [ -z "$name" ]
+  then
+    name=$(< package.json jq -r .name)
+fi
+
+# get `version` from `package.json` of the library, if not supplied as an argument 
+if [ -z "$version" ]
+  then
+    version=$(< package.json jq -r .version)
+fi
 
 # navigate to specified directory
 cd "$directory" || throw "$directory does not exist, cannot navigate."


### PR DESCRIPTION
- add optional arguments `name` and `version`.

Closes issue:
- https://github.com/dequelabs/attest-release-scripts/issues/9

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen