### PR TITLE
fix: ensure version can be parsed from gemspec

### DIFF
--- a/src/ruby-github-release.sh
+++ b/src/ruby-github-release.sh
@@ -23,8 +23,8 @@ GEMSPEC_COUNT=$(find . -type f -name "*.gemspec" | wc -l | tr -d "[:space:]")
 # Find .gemspec file.
 GEMSPEC_FILE=$(ls ./*.gemspec)
 
-# Parse the version number.
-PKG_VERSION=$(perl -nle 'print "$1" if m{spec\.version\s+=\s"(.*)"}' "$GEMSPEC_FILE")
+# Parse the version number (strip either single or double quotes around the version number if any)
+PKG_VERSION=$(perl -nle 'print "$1" if m{spec\.version\s+=\s(.*)}' "$GEMSPEC_FILE" | tr -d "'" | tr -d '"')
 
 # Ensure we read a version.
 [[ -z $PKG_VERSION ]] && throw "Unable to parse version"


### PR DESCRIPTION
The release script failed when `version` in a `gemspec` file could not be parsed, when surrounded by single quote. Eg: `spec.version = '2.3.0'`.

This failed this build - https://circleci.com/gh/dequelabs/axe-matchers/212?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link.

This change allows for `version` to be parsed with quotes, which are later stripped.

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated, a DU ticket, or requires no documentation change
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Stephen 