### PR TITLE
feat: automatically adding release notes from changelog 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
       - image: hamroctopus/shellcheck:1.0.0
     steps:
       - checkout
-      - run: shellcheck src/*
+      - run: shellcheck -e SC2059 src/*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,4 +5,4 @@ jobs:
       - image: hamroctopus/shellcheck:1.0.0
     steps:
       - checkout
-      - run: shellcheck -e SC2059 src/*
+      - run: shellcheck src/*

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -7,14 +7,35 @@ throw() {
   exit 1
 }
 
-# Ensure required env vars are set.
-[ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
-[ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
-[ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
+get_changelog () {
+  changelog=""
+  has_start_line=0
+  while read line; do
+    if [[ $has_start_line -eq 0 ]]; then
+      # If we do not have a starting line, look for one.
+      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+        has_start_line=1
+      fi
+    elif [[ $has_start_line -eq 1 ]]; then
+      # If we do have a starting line, look for a closing line. Either exit the loop or append to the changelog.
+      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+        break
+      else
+        changelog=$"$changelog\n$line"
+      fi
+    fi
+  done <CHANGELOG.md
+  printf "$changelog"
+}
 
-# Ensure https://github.com/aktau/github-release is installed.
-# NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
-command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
+# Ensure required env vars are set.
+# [ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
+# [ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
+# [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
+
+# # Ensure https://github.com/aktau/github-release is installed.
+# # NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
+# command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Parse the version number.
 PKG_VERSION=
@@ -34,9 +55,9 @@ done < pom.xml
 echo "Releasing v$PKG_VERSION"
 
 # Create a release.
-github-release.v0 release \
+echo github-release.v0 release \
   --user "$CIRCLE_PROJECT_USERNAME" \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \
   --name "Release $PKG_VERSION" \
-  --description "Public v$PKG_VERSION release"
+  --description "\'$(get_changelog)\'"

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -13,18 +13,21 @@ get_changelog () {
   while read -r line; do
     if [[ $has_start_line -eq 0 ]]; then
       # If we do not have a starting line, look for one.
-      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+      if [[ "$line" =~ \#\ \[?[[:digit:]] ]]; then
         has_start_line=1
       fi
     elif [[ $has_start_line -eq 1 ]]; then
       # If we do have a starting line, look for a closing line. Either exit the loop or append to the changelog.
-      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+      if [[ "$line" =~ \#\ \[?[[:digit:]] ]]; then
         break
       else
         changelog=$"$changelog\n$line"
       fi
     fi
   done <CHANGELOG.md
+
+  # Ignore rule `SC2059` as we do *not* want newlines/etc escaped here.
+  # shellcheck disable=SC2059
   printf "$changelog"
 }
 

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -33,8 +33,8 @@ get_changelog () {
 [ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
 [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
 
-# # Ensure https://github.com/aktau/github-release is installed.
-# # NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
+# Ensure https://github.com/aktau/github-release is installed.
+# NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
 command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Parse the version number.

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -25,7 +25,7 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
-  printf $changelog
+  printf "$changelog"
 }
 
 # Ensure required env vars are set.

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -25,7 +25,6 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
-  printf "$changelog"
 }
 
 # Ensure required env vars are set.

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -25,6 +25,7 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
+  printf $changelog
 }
 
 # Ensure required env vars are set.

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -10,7 +10,7 @@ throw() {
 get_changelog () {
   changelog=""
   has_start_line=0
-  while read line; do
+  while read -r line; do
     if [[ $has_start_line -eq 0 ]]; then
       # If we do not have a starting line, look for one.
       if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then

--- a/src/java-github-release.sh
+++ b/src/java-github-release.sh
@@ -29,13 +29,13 @@ get_changelog () {
 }
 
 # Ensure required env vars are set.
-# [ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
-# [ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
-# [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
+[ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
+[ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
+[ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
 
 # # Ensure https://github.com/aktau/github-release is installed.
 # # NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
-# command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
+command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Parse the version number.
 PKG_VERSION=
@@ -55,9 +55,9 @@ done < pom.xml
 echo "Releasing v$PKG_VERSION"
 
 # Create a release.
-echo github-release.v0 release \
+github-release.v0 release \
   --user "$CIRCLE_PROJECT_USERNAME" \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \
   --name "Release $PKG_VERSION" \
-  --description "\'$(get_changelog)\'"
+  --description "$(get_changelog)"

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -13,18 +13,21 @@ get_changelog () {
   while read -r line; do
     if [[ $has_start_line -eq 0 ]]; then
       # If we do not have a starting line, look for one.
-      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+      if [[ "$line" =~ \#\ \[?[[:digit:]] ]]; then
         has_start_line=1
       fi
     elif [[ $has_start_line -eq 1 ]]; then
       # If we do have a starting line, look for a closing line. Either exit the loop or append to the changelog.
-      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+      if [[ "$line" =~ \#\ \[?[[:digit:]] ]]; then
         break
       else
         changelog=$"$changelog\n$line"
       fi
     fi
   done <CHANGELOG.md
+
+  # Ignore rule `SC2059` as we do *not* want newlines/etc escaped here.
+  # shellcheck disable=SC2059
   printf "$changelog"
 }
 

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -25,7 +25,7 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
-  printf $changelog
+  printf "$changelog"
 }
 
 # Ensure required env vars are set.

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -10,7 +10,7 @@ throw() {
 get_changelog () {
   changelog=""
   has_start_line=0
-  while read line; do
+  while read -r line; do
     if [[ $has_start_line -eq 0 ]]; then
       # If we do not have a starting line, look for one.
       if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
@@ -25,17 +25,17 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
-  printf "$changelog"
+  echo "$changelog"
 }
 
 # # Ensure required env vars are set.
-[ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
-[ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
-[ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
+# [ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
+# [ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
+# [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
 
 # Ensure https://github.com/aktau/github-release is installed.
 # NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
-command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
+# command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Read version number. Attempt `lerna.json` before `package.json`.
 PKG_VERSION=
@@ -54,7 +54,7 @@ fi
 echo "Releasing v$PKG_VERSION"
 
 # Create a release.
-github-release.v0 release \
+echo github-release.v0 release \
   --user "$CIRCLE_PROJECT_USERNAME" \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -25,6 +25,7 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
+  printf $changelog
 }
 
 # Ensure required env vars are set.

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -29,13 +29,13 @@ get_changelog () {
 }
 
 # # Ensure required env vars are set.
-# [ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
-# [ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
-# [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
+[ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
+[ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
+[ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
 
 # Ensure https://github.com/aktau/github-release is installed.
 # NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
-# command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
+command -v github-release.v0 > /dev/null 2>&1 || throw "Unable to locate github-release binary"
 
 # Read version number. Attempt `lerna.json` before `package.json`.
 PKG_VERSION=
@@ -54,7 +54,7 @@ fi
 echo "Releasing v$PKG_VERSION"
 
 # Create a release.
-echo github-release.v0 release \
+github-release.v0 release \
   --user "$CIRCLE_PROJECT_USERNAME" \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -7,7 +7,28 @@ throw() {
   exit 1
 }
 
-# Ensure required env vars are set.
+get_changelog () {
+  changelog=""
+  has_start_line=0
+  while read line; do
+    if [[ $has_start_line -eq 0 ]]; then
+      # If we do not have a starting line, look for one.
+      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+        has_start_line=1
+      fi
+    elif [[ $has_start_line -eq 1 ]]; then
+      # If we do have a starting line, look for a closing line. Either exit the loop or append to the changelog.
+      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+        break
+      else
+        changelog=$"$changelog\n$line"
+      fi
+    fi
+  done <CHANGELOG.md
+  printf "$changelog"
+}
+
+# # Ensure required env vars are set.
 [ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
 [ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
 [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
@@ -38,4 +59,4 @@ github-release.v0 release \
   --repo "$CIRCLE_PROJECT_REPONAME" \
   --tag "v$PKG_VERSION" \
   --name "Release $PKG_VERSION" \
-  --description "Public v$PKG_VERSION release"
+  --description "$(get_changelog)"

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -25,10 +25,9 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
-  echo "$changelog"
 }
 
-# # Ensure required env vars are set.
+# Ensure required env vars are set.
 [ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
 [ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
 [ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"

--- a/src/ruby-github-release.sh
+++ b/src/ruby-github-release.sh
@@ -13,18 +13,21 @@ get_changelog () {
   while read -r line; do
     if [[ $has_start_line -eq 0 ]]; then
       # If we do not have a starting line, look for one.
-      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+      if [[ "$line" =~ \#\ \[?[[:digit:]] ]]; then
         has_start_line=1
       fi
     elif [[ $has_start_line -eq 1 ]]; then
       # If we do have a starting line, look for a closing line. Either exit the loop or append to the changelog.
-      if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then
+      if [[ "$line" =~ \#\ \[?[[:digit:]] ]]; then
         break
       else
         changelog=$"$changelog\n$line"
       fi
     fi
   done <CHANGELOG.md
+
+  # Ignore rule `SC2059` as we do *not* want newlines/etc escaped here.
+  # shellcheck disable=SC2059
   printf "$changelog"
 }
 

--- a/src/ruby-github-release.sh
+++ b/src/ruby-github-release.sh
@@ -25,7 +25,7 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
-  printf $changelog
+  printf "$changelog"
 }
 
 # Ensure required env vars are set.

--- a/src/ruby-github-release.sh
+++ b/src/ruby-github-release.sh
@@ -25,7 +25,6 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
-  printf "$changelog"
 }
 
 # Ensure required env vars are set.

--- a/src/ruby-github-release.sh
+++ b/src/ruby-github-release.sh
@@ -25,6 +25,7 @@ get_changelog () {
       fi
     fi
   done <CHANGELOG.md
+  printf $changelog
 }
 
 # Ensure required env vars are set.

--- a/src/ruby-github-release.sh
+++ b/src/ruby-github-release.sh
@@ -10,7 +10,7 @@ throw() {
 get_changelog () {
   changelog=""
   has_start_line=0
-  while read line; do
+  while read -r line; do
     if [[ $has_start_line -eq 0 ]]; then
       # If we do not have a starting line, look for one.
       if [[ "$line" =~ \#\ \[[[:digit:]] ]]; then


### PR DESCRIPTION
Used @stephenmathieson function to add changelog content to Github release for attest-ruby/java/node 

Test results `attest-java`:
https://github.com/dequelabs/attest-java/blob/develop/CHANGELOG.md
```
Releasing v3.5.1
github-release.v0 release --user  --repo  --tag v3.5.1 --name Release 3.5.1 --description


### Bug Fixes

* IsAuditedForAccessibility should log by default ([#80](https://github.com/dequelabs/attest-java/issues/80)) ([9550f22](https://github.com/dequelabs/attest-java/commit/9550f22))
```

Test results `attest-ruby`:
https://github.com/dequelabs/attest-ruby/blob/develop/CHANGELOG.md
```
Releasing v2.4.0
github-release.v0 release --user  --repo  --tag v2.4.0 --name Release 2.4.0 --description

### Bug Fixes

- not use named capture groups in cucumber step regex ([#60](https://github.com/dequelabs/attest-ruby/issues/60)) ([58f4443](https://github.com/dequelabs/attest-ruby/commit/58f4443))
- Rspec examples test failures ([#47](https://github.com/dequelabs/attest-ruby/issues/47)) ([e0734f2](https://github.com/dequelabs/attest-ruby/commit/e0734f2))

### Features

- update to axe-matchers v2.4.1 ([53a6a2b](https://github.com/dequelabs/attest-ruby/commit/53a6a2b))
```

Test results `attest-node-suite`:
https://github.com/dequelabs/attest-node-suite/blob/develop/CHANGELOG.md
```
Releasing v2.8.1
github-release.v0 release --user  --repo  --tag v2.8.1 --name Release 2.8.1 --description


### Bug Fixes

* **aget:** Enable writing json uri mode ([#331](http://dequelabs/attest-node-suite/issues/331)) ([d3ffc6a](http://dequelabs/attest-node-suite/commits/d3ffc6a))
* **aget:** stub util test properly to allow for cross platform testing ([#280](http://dequelabs/attest-node-suite/issues/280)) ([8dd851b](http://dequelabs/attest-node-suite/commits/8dd851b))
* **aget:** Support Node v8 ([#264](http://dequelabs/attest-node-suite/issues/264)) ([da94013](http://dequelabs/attest-node-suite/commits/da94013))
* **attest-standards:** Allow from a dynamic list of tags ([#295](http://dequelabs/attest-node-suite/issues/295)) ([e885721](http://dequelabs/attest-node-suite/commits/e885721))
```

Closes issue: https://github.com/dequelabs/HTMLToolsTeamHub/issues/70

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated, a DU ticket, or requires no documentation change
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
