### PR TITLE
fix: generate gh compatible header ids

### DIFF
--- a/src/md-to-html.sh
+++ b/src/md-to-html.sh
@@ -42,7 +42,7 @@ for file in $files
     # replace md extenstion with html
     outputFile="${newPath/.md/.html}"
     # convert
-    npx showdown makehtml -i "$file" -o "$outputFile" --tables
+    npx showdown makehtml -i "$file" -o "$outputFile" --tables --ghCompatibleHeaderId
 done
 
 unset IFS 


### PR DESCRIPTION
Because @jeankaplansky wants to use a plugin to autogenerate TOC above her documentations & this plugin creates links to headers in the page in a github compatible fashion.

For example today's scripts create a hyperlink with id `#downloadableexamples`, but after this change it will be `#downloadable-examples` which is in line with what the TOC plugin does.

Sample page where these links do not work right now [C Sharp Docs](https://dequeuniversity.com/guide/attest-csharp/1.0/attest-csharp-examples). But should work after this change is in effect.

Further docs on the options from showdown is here - https://github.com/showdownjs/showdown#valid-options

Closes issue:
- NA

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
