### PR TITLE
fix: disable the requirement of indenting sublists by 4 spaces

### DIFF
--- a/src/md-to-html.sh
+++ b/src/md-to-html.sh
@@ -42,7 +42,7 @@ for file in $files
     # replace md extenstion with html
     outputFile="${newPath/.md/.html}"
     # convert
-    npx showdown makehtml -i "$file" -o "$outputFile" --tables --ghCompatibleHeaderId
+    npx showdown makehtml -i "$file" -o "$outputFile" --tables --ghCompatibleHeaderId --disableForced4SpacesIndentedSublists
 done
 
 unset IFS 


### PR DESCRIPTION
Currently in documentation markdown files 2 spaces are used to indent sublists. The de-facto expectation of showdown seems to be 4 spaces instead to 2, hence setting the disable flag as an option.

> Note: Verified that this change works as expected by running the markdown transformation locally.

Closes issue:
- https://github.com/dequelabs/attest-docs/issues/59

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Code is reviewed for security
