### PR TITLE
feat: allow markdown convertor to parse image dimensions

### DIFF
--- a/src/md-to-html.sh
+++ b/src/md-to-html.sh
@@ -42,7 +42,7 @@ for file in $files
     # replace md extenstion with html
     outputFile="${newPath/.md/.html}"
     # convert
-    npx showdown makehtml -i "$file" -o "$outputFile" --tables --ghCompatibleHeaderId --disableForced4SpacesIndentedSublists
+    npx showdown makehtml -i "$file" -o "$outputFile" --tables --ghCompatibleHeaderId --disableForced4SpacesIndentedSublists --parseImgDimensions
 done
 
 unset IFS 


### PR DESCRIPTION
@jeankaplansky wanted to have this option enabled with showdown.
See more documentation here - https://github.com/showdownjs/showdown/wiki/Showdown-Options#parseimgdimensions

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Code is reviewed for security
