### PR TITLE
Add `docker-push-to-ecr`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Creates GitHub Releases in Ruby projects. Will derive the release name from the 
 
 Build and deploy a Docker image to ECR.
 
-Requires the following environment variables are exported:
+Requires the following environment variables to be exported:
 
 - `CIRCLE_BRANCH` (always set by CircleCI)
 - `DEV_AWS_SECRET_ACCESS_KEY` (set by the `html-team` CircleCI context)

--- a/README.md
+++ b/README.md
@@ -32,41 +32,89 @@ Creates GitHub Releases in Java projects. Will derive the release name from the 
 
 Creates GitHub Releases in Ruby projects. Will derive the release name from the "version" key in `*.gemspec`.
 
+### docker-push-to-ecr.sh
+
+Build and deploy a Docker image to ECR.
+
+Requires the following environment variables are exported:
+
+- `CIRCLE_BRANCH` (always set by CircleCI)
+- `DEV_AWS_SECRET_ACCESS_KEY` (set by the `html-team` CircleCI context)
+- `DEV_AWS_ACCESS_KEY_ID` (set by the `html-team` CircleCI context)
+- `DEV_ECR` (your service's dev ECR)
+- `QA_ECR` (your service's QA ECR)
+
+```
+docker-push-to-ecr.sh [options]
+
+  Build and push a Docker image to ECR. Uses the current Git SHA as the
+  image's version number and $CIRCLE_BRANCH to derive which ECR to
+  push to.
+
+  Will append a "-production" suffix to production (master branch)
+  images.
+
+  Options
+    --dockerfile=[path]    Path to the Dockerfile (defaults to ".")
+    --docker-args=[args]   Arguments to pass to `docker build`
+    --suffix=[suffix]      Suffix to add to the image tag
+```
+
+**Examples**
+
+Build/push `./Dockerfile` with no additional arguments passed to Docker with the default image tag:
+
+```
+./docker-push-to-ecr.sh
+```
+
+Build/push `./service/Dockerfile` and set the `npm_auth` [build-arg](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg):
+
+```
+./docker-push-to-ecr.sh --docker-args="--build-arg npm_auth='$NPM_AUTH_PRIVATE' --dockerfile="./service"
+```
+
+Build/push `./Dockerfile` with the `-stephentest` suffix:
+
+```
+./docker-push-to-ecr.sh --suffix="-stephentest"
+```
+
 ### zip-dir-upload-to-artifactory.sh
 
 The `zip-dir-upload-to-artifactory` script zip's a given directory and uploads the zip file to artifactory (agora). The script accepts 2 arguments, in the below order respectively:
 
-| Argument | Description |
-|---|---|
-| dir ($1) | **(Mandatory)** the directory to zip |
-| prefix ($2) | **(Optional)** a prefix to the zip file name |
-| name ($2) | **(Optional)** name used as path under artifactory repository to where the zip file will be uploaded |
-| version ($2) | **(Optional)** version number used to construct the zip file name |
+| Argument      | Description                                                                                          |
+| ------------- | ---------------------------------------------------------------------------------------------------- |
+| dir (\$1)     | **(Mandatory)** the directory to zip                                                                 |
+| prefix (\$2)  | **(Optional)** a prefix to the zip file name                                                         |
+| name (\$2)    | **(Optional)** name used as path under artifactory repository to where the zip file will be uploaded |
+| version (\$2) | **(Optional)** version number used to construct the zip file name                                    |
 
 **Usage:**
 
 ```
 zip-dir-upload-to-artifactory.sh dist "next-$(git rev-parse --short HEAD)"
-``` 
+```
 
-where argument, `dist`  is the directory to zip and `next-$(git rev-parse --short HEAD)` is an optional prefix to the generated zip file name.
+where argument, `dist` is the directory to zip and `next-$(git rev-parse --short HEAD)` is an optional prefix to the generated zip file name.
 
->Note: The `zip-dir-upload-to-artifactory` script is put together for use in CI (circle), and expects `ARTIFACTORY_REPO` and `ARTIFACTORY_API_KEY` as environment variables. Ensure these are configured and available when used in other setups.
+> Note: The `zip-dir-upload-to-artifactory` script is put together for use in CI (circle), and expects `ARTIFACTORY_REPO` and `ARTIFACTORY_API_KEY` as environment variables. Ensure these are configured and available when used in other setups.
 
 ### md-to-html
 
 The `md-to-html` script converts a given collection of markdown files to html. The script accepts 2 arguments in the below order respectively:
 
-| Argument | Description |
-|---|---|
-| inputDir ($1) | **(Mandatory)** input directory containing markdown files to convert |
-| destDir ($1) | **(Mandatory)** destination directory to created the converted html files |
+| Argument       | Description                                                               |
+| -------------- | ------------------------------------------------------------------------- |
+| inputDir (\$1) | **(Mandatory)** input directory containing markdown files to convert      |
+| destDir (\$1)  | **(Mandatory)** destination directory to created the converted html files |
 
 **Usage:**
 
 ```
 md-to-html.sh docs output
-``` 
+```
 
 where argument, `docs` are the markdown files and `output` is the directory in which the html files are created.
 

--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+set -e
+
+function throw() {
+  echo "Error: $*"
+  exit 1
+}
+
+function usage() {
+  echo "docker-push-to-ecr.sh [options]"
+  echo ""
+  echo "  Build and push a Docker image to ECR. Uses the current Git SHA as the"
+  echo "  image's version number and \$CIRCLE_BRANCH to derive which ECR to"
+  echo "  push to."
+  echo ""
+  echo "  Will append a \"-production\" suffix to production (master branch)"
+  echo "  images."
+  echo ""
+  echo "  Options"
+  echo "    --dockerfile=[path]    Path to the Dockerfile (defaults to \".\")"
+  echo "    --docker-args=[args]   Arguments to pass to \`docker build\`"
+  echo "    --suffix=[suffix]      Suffix to add to the image tag"
+  echo ""
+}
+
+function main() {
+  if [ $# -eq 0 ]; then
+    usage
+    exit 1
+  fi
+
+  readonly Branch="$CIRCLE_BRANCH"
+  readonly Version=$(git rev-parse --short HEAD)
+  local Repo=""
+  local Secret=""
+  local Key=""
+  local Suffix=""
+  local Dockerfile="."
+  local DockerArgs=""
+
+  for i in "$@"; do
+    case $i in
+    --suffix=*)
+      Suffix="${i#*=}"
+      shift
+      ;;
+    --dockerfile=*)
+      Dockerfile="${i#*=}"
+      shift
+      ;;
+    --docker-args=*)
+      DockerArgs="${i#*=}"
+      shift
+      ;;
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      throw "Unknown option provided: \"$i\""
+      ;;
+    esac
+  done
+
+  # Check env vars.
+  [ -z "$CIRCLE_BRANCH" ] && throw "CIRCLE_BRANCH not set"
+  [ -z "$DEV_AWS_SECRET_ACCESS_KEY" ] && throw "DEV_AWS_SECRET_ACCESS_KEY not set"
+  [ -z "$DEV_AWS_ACCESS_KEY_ID" ] && throw "DEV_AWS_ACCESS_KEY_ID not set"
+  [ -z "$DEV_ECR" ] && throw "DEV_ECR not set"
+  [ -z "$QA_ECR" ] && throw "QA_ECR not set"
+
+  # Ensure we figured out branch/SHA.
+  [ -z "$Branch" ] && throw "Branch required - set \$CIRCLE_BRANCH."
+  [ -z "$Version" ] && throw "Unable to derive version - is this a Git repo?"
+
+  if [ "$Branch" = "master" ]; then
+    # Deploy develop commits to our development ECR for now. We don't want to give CI access to AWS prod, so instead, we simply deploy to dev with a `-production` Suffix.
+    Repo=$DEV_ECR
+    # Do not overwrite the user-provided suffix.
+    if [ -z "$Suffix" ]; then
+      Suffix="-production"
+    fi
+    # TODO: These should be `PROD_` keys.
+    Secret=$DEV_AWS_SECRET_ACCESS_KEY
+    Key=$DEV_AWS_ACCESS_KEY_ID
+  elif [ "$Branch" = "release" ]; then
+    # Deploy develop commits to our QA ECR.
+    Repo=$QA_ECR
+    # Since QA is in the same AWS account as dev, we can re-use the keys.
+    Secret=$DEV_AWS_SECRET_ACCESS_KEY
+    Key=$DEV_AWS_ACCESS_KEY_ID
+  elif [ "$Branch" = "develop" ]; then
+    Repo=$DEV_ECR
+    Secret=$DEV_AWS_SECRET_ACCESS_KEY
+    Key=$DEV_AWS_ACCESS_KEY_ID
+  else
+    throw "Refusing to push from unsupported branch ($Branch)"
+  fi
+
+  [ -z "$Repo" ] && throw "Unable to set ECR"
+  [ -z "$Key" ] && throw "Unable to set AWS access key ID"
+  [ -z "$Secret" ] && throw "Unable to set AWS secret access key"
+
+  echo "Authenticating with AWS"
+  # AWS_ACCESS_KEY_ID=$Key AWS_SECRET_ACCESS_KEY=$Secret aws ecr get-login --no-include-email --region us-east-1 | /bin/bash
+
+  echo "Building, tagging and pushing version $Version$Suffix"
+  echo docker build "$DockerArgs" -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
+  echo docker push "$Repo:latest$Suffix"
+  echo docker push "$Repo:$Version$Suffix"
+
+  echo "Done!"
+}
+
+main "$@"

--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -103,12 +103,12 @@ function main() {
   [ -z "$Secret" ] && throw "Unable to set AWS secret access key"
 
   echo "Authenticating with AWS"
-  # AWS_ACCESS_KEY_ID=$Key AWS_SECRET_ACCESS_KEY=$Secret aws ecr get-login --no-include-email --region us-east-1 | /bin/bash
+  AWS_ACCESS_KEY_ID=$Key AWS_SECRET_ACCESS_KEY=$Secret aws ecr get-login --no-include-email --region us-east-1 | /bin/bash
 
   echo "Building, tagging and pushing version $Version$Suffix"
-  echo docker build "$DockerArgs" -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
-  echo docker push "$Repo:latest$Suffix"
-  echo docker push "$Repo:$Version$Suffix"
+  docker build "$DockerArgs" -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
+  docker push "$Repo:latest$Suffix"
+  docker push "$Repo:$Version$Suffix"
 
   echo "Done!"
 }


### PR DESCRIPTION
This patch adds a script for building/pushing a Docker image to an ECR. As result of the "infra catchup" discussion yesterday, I decided to build a more general-purpose script to use in all of our microservices for pushing to their ECRs.

The script was based on the following:

- https://github.com/dequelabs/walnut/blob/develop/scripts/docker-push.sh
- https://github.com/dequelabs/axe-linter/blob/develop/.circleci/deploy-docker-image.sh
- https://github.com/dequelabs/axe-pro-ml-service/blob/develop/.circleci/deploy-docker-image.sh
- https://github.com/dequelabs/auth-service/blob/develop/docker/deploy.sh
- https://github.com/dequelabs/axe-netlify/blob/develop/.circleci/deploy-docker-image.sh
- https://github.com/dequelabs/attest-usage-service/blob/develop/.circleci/deploy-service.sh

We should be able to replace the above (and others service's custom build stuff) with this script.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
