### PR TITLE
fix(docker-push): Do not fail if no arguments are provided

### DIFF
--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -25,11 +25,6 @@ function usage() {
 }
 
 function main() {
-  if [ $# -eq 0 ]; then
-    usage
-    exit 1
-  fi
-
   readonly Branch="$CIRCLE_BRANCH"
   readonly Version=$(git rev-parse --short HEAD)
   local Repo=""


### PR DESCRIPTION
The most common usage of this will just be:

```
./docker-push-to-ecr.sh
```

So failing here is not desirable 🤦


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
