### PR TITLE
fix(docker-push-to-ecr): Allow not passing `--docker-args`

### DIFF
--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -101,7 +101,11 @@ function main() {
   AWS_ACCESS_KEY_ID=$Key AWS_SECRET_ACCESS_KEY=$Secret aws ecr get-login --no-include-email --region us-east-1 | /bin/bash
 
   echo "Building, tagging and pushing version $Version$Suffix"
-  docker build "$DockerArgs" -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
+  if [ -z "$DockerArgs" ]; then
+    docker build -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
+  else
+    docker build "$DockerArgs" -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
+  fi
   docker push "$Repo:latest$Suffix"
   docker push "$Repo:$Version$Suffix"
 


### PR DESCRIPTION
This patch updates the `docker-push-to-ecr` script, allowing it to be used without passing `--docker-args`. Previously, without passing args, the script would error with:

```
Authenticating with AWS
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
WARNING! Your password will be stored unencrypted in /home/circleci/.docker/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

Login Succeeded
Building, tagging and pushing version 619617c
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -

Build an image from a Dockerfile

Exited with code exit status 1
```

This is due to invoking `docker build` with:

```
docker build "" -t "ecr:latest" -t "ecr:ABCD1234" "."
```

IMO this is something that `docker build` should support/handle, but it's easy enough for us to work around it here.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
