### PR TITLE
fix(docker-push-to-ecr): Correctly pass custom args to docker

### DIFF
--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -101,11 +101,8 @@ function main() {
   AWS_ACCESS_KEY_ID=$Key AWS_SECRET_ACCESS_KEY=$Secret aws ecr get-login --no-include-email --region us-east-1 | /bin/bash
 
   echo "Building, tagging and pushing version $Version$Suffix"
-  if [ -z "$DockerArgs" ]; then
-    docker build -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
-  else
-    docker build "$DockerArgs" -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
-  fi
+  # shellcheck disable=SC2086
+  docker build $DockerArgs -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
   docker push "$Repo:latest$Suffix"
   docker push "$Repo:$Version$Suffix"
 


### PR DESCRIPTION
This patch applies the alternate solution from #25. By quoting `$DockerArgs`, the build script gets confused and errors with:

```
Authenticating with AWS
WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Login Succeeded
Building, tagging and pushing version 5cb85268-TESTING
unknown flag: --build-arg npmauth
See 'docker build --help'.
```

Instead, we're just going to disable the ShellCheck rule and move on.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
