### PR TITLE
feat(docker-push-to-ecr): Add a `--force` flag for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ docker-push-to-ecr.sh [options]
     --dockerfile=[path]    Path to the Dockerfile (defaults to ".")
     --docker-args=[args]   Arguments to pass to `docker build`
     --suffix=[suffix]      Suffix to add to the image tag
+    --force                Force the script to push a "dev" image
 ```
+
+The `--force` flag is useful for testing Docker deployments. It should only be used in "special" scenarios (eg repository/service setup).
 
 **Examples**
 

--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -76,6 +76,7 @@ function main() {
   [ -z "$Version" ] && throw "Unable to derive version - is this a Git repo?"
 
   if [ "$Force" = true ]; then
+    echo "Warning: --force flag provided. Ignoring branch and pushing a \"dev\" image!"
     # If the script was run with `--force`, we'll _always_ push a "dev" image to the dev ECR.
     Repo=$DEV_ECR
     Secret=$DEV_AWS_SECRET_ACCESS_KEY
@@ -110,10 +111,6 @@ function main() {
   [ -z "$Repo" ] && throw "Unable to set ECR"
   [ -z "$Key" ] && throw "Unable to set AWS access key ID"
   [ -z "$Secret" ] && throw "Unable to set AWS secret access key"
-
-  if [ "$Force" = true ]; then
-    echo "Warning: --force flag provided. Ignoring branch and pushing a \"dev\" image!"
-  fi
 
   echo "Authenticating with AWS"
   AWS_ACCESS_KEY_ID=$Key AWS_SECRET_ACCESS_KEY=$Secret aws ecr get-login --no-include-email --region us-east-1 | /bin/bash

--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -76,8 +76,8 @@ function main() {
   [ -z "$Version" ] && throw "Unable to derive version - is this a Git repo?"
 
   if [ "$Force" = true ]; then
-    echo "Warning: --force flag provided. Ignoring branch and pushing a \"dev\" image!"
     # If the script was run with `--force`, we'll _always_ push a "dev" image to the dev ECR.
+    echo "Warning: --force flag provided. Ignoring branch and pushing a \"dev\" image!"
     Repo=$DEV_ECR
     Secret=$DEV_AWS_SECRET_ACCESS_KEY
     Key=$DEV_AWS_ACCESS_KEY_ID


### PR DESCRIPTION
This patch introduces a `--force` flag to the Docker push script. This will be used for testing our build process(es) when refactoring/creating services.

This flag **SHOULD NOT** be used by default, but instead, only when absolutely required.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
