### PR TITLE
fix(docker-push-to-ecr): Always use a 8-character tag

### DIFF
--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -27,7 +27,8 @@ function usage() {
 
 function main() {
   readonly Branch="$CIRCLE_BRANCH"
-  readonly Version=$(git rev-parse --short HEAD)
+  # Always use 8 characters. This ensures consistency with image tags.
+  readonly Version=$(git rev-parse --short=8 HEAD)
   local Repo=""
   local Secret=""
   local Key=""


### PR DESCRIPTION
This patch updates the Docker push script, ensuring it _always_ uses a 7-character tag. Previously, in some repositories, an 8 character string would be returned (and a 7 character string in others). This avoids the inconsistency and ensures image tags are always the same length.


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
