### PR TITLE
fix(docker-push-to-ecr): Stop pushing `:latest` image

### DIFF
--- a/src/docker-push-to-ecr.sh
+++ b/src/docker-push-to-ecr.sh
@@ -118,8 +118,7 @@ function main() {
 
   echo "Building, tagging and pushing version $Version$Suffix"
   # shellcheck disable=SC2086
-  docker build $DockerArgs -t "$Repo:latest$Suffix" -t "$Repo:$Version$Suffix" "$Dockerfile"
-  docker push "$Repo:latest$Suffix"
+  docker build $DockerArgs -t "$Repo:$Version$Suffix" "$Dockerfile"
   docker push "$Repo:$Version$Suffix"
 
   echo "Done!"


### PR DESCRIPTION
This patch removes pushing the `:latest` tag, as we don't really need it for anything, and we're making our ECRs immutable moving forward.

BREAKING CHANGE: the the `docker-push-to-ecr` script no longer deploys a `latest` image. Update your `docker-compose.yml` and CloudFormation templates to use Git SHAs instead.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
