### PR TITLE
chore: allow users to change the target branch when creating a tag.

### DIFF
--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -56,7 +56,7 @@ fi
 
 echo "Releasing v$PKG_VERSION"
 
-if [ -z $GITHUB_RELEASE_TARGET ]; then
+if [ -z "$GITHUB_RELEASE_TARGET" ]; then
   # Create a release.
   github-release.v0 release \
     --user "$CIRCLE_PROJECT_USERNAME" \

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -56,21 +56,16 @@ fi
 
 echo "Releasing v$PKG_VERSION"
 
-if [ -z "$GITHUB_RELEASE_TARGET" ]; then
-  # Create a release.
-  github-release.v0 release \
-    --user "$CIRCLE_PROJECT_USERNAME" \
-    --repo "$CIRCLE_PROJECT_REPONAME" \
-    --tag "v$PKG_VERSION" \
-    --name "Release $PKG_VERSION" \
-    --description "$(get_changelog)"
-else 
-  # Create a release with a target branch
-  github-release.v0 release \
-    --user "$CIRCLE_PROJECT_USERNAME" \
-    --repo "$CIRCLE_PROJECT_REPONAME" \
-    --tag "v$PKG_VERSION" \
-    --target "$GITHUB_RELEASE_TARGET" \
-    --name "Release $PKG_VERSION" \
-    --description "$(get_changelog)"
+args=(
+  --user "$CIRCLE_PROJECT_USERNAME" 
+  --repo "$CIRCLE_PROJECT_REPONAME" 
+  --tag "v$PKG_VERSION" 
+  --name "Release $PKG_VERSION"
+)
+
+if [ -n "$GITHUB_RELEASE_TARGET" ]; then
+  args+=("--target" "$GITHUB_RELEASE_TARGET")
 fi
+
+# Create a release.
+github-release.v0 release "${args[@]}" --description "$(get_changelog)"

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -56,10 +56,21 @@ fi
 
 echo "Releasing v$PKG_VERSION"
 
-# Create a release.
-github-release.v0 release \
-  --user "$CIRCLE_PROJECT_USERNAME" \
-  --repo "$CIRCLE_PROJECT_REPONAME" \
-  --tag "v$PKG_VERSION" \
-  --name "Release $PKG_VERSION" \
-  --description "$(get_changelog)"
+if [ -z $GITHUB_RELEASE_TARGET ]; then
+  # Create a release.
+  github-release.v0 release \
+    --user "$CIRCLE_PROJECT_USERNAME" \
+    --repo "$CIRCLE_PROJECT_REPONAME" \
+    --tag "v$PKG_VERSION" \
+    --name "Release $PKG_VERSION" \
+    --description "$(get_changelog)"
+else 
+  # Create a release with a target branch
+  github-release.v0 release \
+    --user "$CIRCLE_PROJECT_USERNAME" \
+    --repo "$CIRCLE_PROJECT_REPONAME" \
+    --tag "v$PKG_VERSION" \
+    --target "$GITHUB_RELEASE_TARGET" \
+    --name "Release $PKG_VERSION" \
+    --description "$(get_changelog)"
+fi


### PR DESCRIPTION
This should allow users to use the `$GITHUB_RELEASE_TARGET` environment variable instead of defaulting to the default GH branch of the repo. 
Ref: https://github.com/dequelabs/axe-core/issues/2486, https://github.com/github-release/github-release/blob/master/github-release.go#L47

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Code is reviewed for security
