### PR TITLE
feat(docker-push-to-ecr): Support pushing directly to production ECRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ docker-push-to-ecr.sh [options]
   image's version number and $CIRCLE_BRANCH to derive which ECR to
   push to.
 
-  Will append a "-production" suffix to production (master branch)
-  images.
+  If $PROD_ECR is not set, will push to the $DEV_ECR and append
+  a "-production" suffix to the image. This functionality will be
+  removed once all services are setup to deploy to their production
+  ECRs.
 
   Options
     --dockerfile=[path]    Path to the Dockerfile (defaults to ".")


### PR DESCRIPTION
This patch enables us to move away from the `-production` image hack. With it, we'll no longer push production images to our dev ECRs.

For now, this is opt-in behavior. To enable this, simply set the following environment variables prior to running the `docker-push-to-ecr` script:

- `PROD_ECR` - the production ECR address
- `PROD_AWS_SECRET_ACCESS_KEY` - secret access key for an IAM user with access to push to ECR
- `PROD_AWS_ACCESS_KEY_ID` - access key id for an IAM user with access to push to ECR

I will be testing this on a few of the micro-services I maintain over the next few weeks/sprints. Once I am confident that it's working as expected, I'll post in Deque's `#infrastructure` slack channel, letting everyone know to add the new variables to their CI setups. About a week after that, I will _remove_ the `-production` hack from this script.

See https://github.com/dequelabs/infrastructure/issues/231


## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
