### PR TITLE
feat(node): support gha env variables

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,6 +1,9 @@
 name: shellcheck
 
 on: [push]
+
+permissions: {}
+
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -6,5 +6,5 @@ jobs:
     name: Shellcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - run: shellcheck src/*

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ The scripts make the following assumptions:
 - `CIRCLE_PROJECT_REPONAME` is exported
 - `CIRCLE_PROJECT_USERNAME` is exported
 
+> [!NOTE]
+> Updates to support GitHub Actions runners are in progress.
+> Starting with `node-github-release.sh` they will start
+> to support `GITHUB_` environment variables as well as
+> CircleCI to transition platforms. Documentation will
+> be updated later once this is done across all the scripts.
+
 ## Scripts
 
 ### node-github-release.sh

--- a/src/node-github-release.sh
+++ b/src/node-github-release.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-throw() { 
+throw() {
   echo "$@" 1>&2
   exit 1
 }
@@ -33,8 +33,24 @@ get_changelog () {
 
 # Ensure required env vars are set.
 [ -z "$GITHUB_TOKEN" ] && throw "GITHUB_TOKEN not set"
-[ -z "$CIRCLE_PROJECT_REPONAME" ] && throw "CIRCLE_PROJECT_REPONAME not set"
-[ -z "$CIRCLE_PROJECT_USERNAME" ] && throw "CIRCLE_PROJECT_USERNAME not set"
+
+# Support both CircleCI and GitHub Actions environment variables
+if [ -n "$CIRCLE_PROJECT_REPONAME" ]; then
+  REPO_NAME="$CIRCLE_PROJECT_REPONAME"
+elif [ -n "$GITHUB_REPOSITORY" ]; then
+  # Extract repo name from GITHUB_REPOSITORY (format: "owner/repo")
+  REPO_NAME="${GITHUB_REPOSITORY#*/}"
+else
+  throw "Neither CIRCLE_PROJECT_REPONAME nor GITHUB_REPOSITORY is set"
+fi
+
+if [ -n "$CIRCLE_PROJECT_USERNAME" ]; then
+  REPO_OWNER="$CIRCLE_PROJECT_USERNAME"
+elif [ -n "$GITHUB_REPOSITORY_OWNER" ]; then
+  REPO_OWNER="$GITHUB_REPOSITORY_OWNER"
+else
+  throw "Neither CIRCLE_PROJECT_USERNAME nor GITHUB_REPOSITORY_OWNER is set"
+fi
 
 # Ensure https://github.com/aktau/github-release is installed.
 # NOTE: we install it from gopkg (gopkg.in/aktau/github-release.v0), so the binary has a `.v0` suffix.
@@ -57,9 +73,9 @@ fi
 echo "Releasing v$PKG_VERSION"
 
 args=(
-  --user "$CIRCLE_PROJECT_USERNAME" 
-  --repo "$CIRCLE_PROJECT_REPONAME" 
-  --tag "v$PKG_VERSION" 
+  --user "$REPO_OWNER"
+  --repo "$REPO_NAME"
+  --tag "v$PKG_VERSION"
   --name "Release $PKG_VERSION"
 )
 


### PR DESCRIPTION
# Background

In moving the `axe-core` deployment to GHA, it was discovered that this repository of scripts has no support for GHA env variables. While we _could_ re-implement the release scripting fresh for GHA, this would take some time to do and ensure alignment with the current scripts behavior.

This patch does 4 things:

- Adds support for the GitHub environment variables when CircleCI ones are not found
- Notes in the readme about this introduction of support starting, but not being complete. Thus not fully documented on behavior patterns yet.
- Pins the checkout workflow instead of using a loose tag (also updates it to current in the process.)
- Restricts the permissions of the workflow to none.

The patch here is non-breaking. The `GITHUB_` variables added should not exist in CircleCI environments. Even if they did, CircleCI takes priority.

# Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Code is reviewed for security
